### PR TITLE
Fix minitest action

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -1,4 +1,4 @@
-name: "Ruby on Rails CI"
+name: "minitest"
 on:
   push:
   pull_request:
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
       # Add or replace dependency steps here
       - name: Install Ruby and gems
-        uses: ruby/setup-ruby@78c01b705fd9d5ad960d432d3a0cfa341d50e410 # v1.179.1
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - name: Install Chrome driver


### PR DESCRIPTION
Uses a newer version of `setup-ruby` in the minitest action which supports the recent ruby version upgrade to 3.4.5